### PR TITLE
Update trtool.c

### DIFF
--- a/trtool.c
+++ b/trtool.c
@@ -37,6 +37,9 @@
 #define MAXSIZE 10240
 #define HOSTLEN 40
 #define CONNECT_NUMBER 5
+#ifndef SIGCLD
+#   define SIGCLD SIGCHLD
+#endif
 
 /* define function here */
 void usage(char *s);


### PR DESCRIPTION
fix trtool.c:132:12: error: use of undeclared identifier 'SIGCLD'